### PR TITLE
Adds teacher invitation method from teachers controller

### DIFF
--- a/app/controllers/teachers_controller.rb
+++ b/app/controllers/teachers_controller.rb
@@ -1,5 +1,6 @@
 class TeachersController < ApplicationController
-  before_action :authorized?
+  before_action :authorized?, only: %i[home rc_invitations accept_invitations]
+  before_action :authenticate_review_center!, only: %i[new_invitation create_invitation]
 
   def home
     @review_centers = current_user.rc_teachers.map { |rc_teacher| ReviewCenter.find(rc_teacher.review_center_id) }
@@ -8,13 +9,42 @@ class TeachersController < ApplicationController
     @lessons = Lesson.where(teacher_subject_id: teacher_subject_ids)
   end
 
-  def invite_teacher; end
+  def new_invitation
+    @rc_teacher = current_review_center.rc_teachers.build
+  end
+
+  def create_invitation
+    @rc_teacher = current_review_center.rc_teachers.new(new_invitation_params)
+    @rc_teacher.user_id = Teacher.find_by(username: params[:rc_teacher][:username])&.id
+    @rc_teacher.review_center_id = current_review_center.id
+    @rc_teacher.status = 'pending'
+
+    if @rc_teacher.save
+      flash[:notice] = 'Successfully sent teacher invitation'
+      redirect_to authenticated_rc_root_path
+    else
+      flash[:error] = @rc_teacher.errors.full_messages.first
+      redirect_to new_invitation_path
+    end
+  end
+
+  def search
+    @teachers = Teacher.where('username like ?', "%#{params[:username]}%").limit(5)
+
+    respond_to do |format|
+      format.js
+    end
+  end
 
   def rc_invitations; end
 
   def accept_invitations; end
 
   private
+
+  def new_invitation_params
+    params.require(:rc_teacher).permit(:user_id, :review_center_id, :status)
+  end
 
   def authorized?
     authenticate_user!

--- a/app/javascript/packs/search_ajax.js
+++ b/app/javascript/packs/search_ajax.js
@@ -1,0 +1,18 @@
+const textField = document.getElementById('search-field')
+
+
+textField.addEventListener('input', function() {
+  const username = this.value
+  console.log(username)
+  
+  $.ajax({
+    type: "GET",
+    url: "/teachers/search",
+    data: { username: username } 
+  });
+})
+
+
+
+
+

--- a/app/models/review_center.rb
+++ b/app/models/review_center.rb
@@ -1,6 +1,7 @@
 class ReviewCenter < ApplicationRecord
-  # Include default devise modules. Others available are:
-  # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
+  has_many :rc_teachers, dependent: :destroy
+  has_many :rc_courses, dependent: :destroy
+
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 

--- a/app/views/teachers/_search.html.erb
+++ b/app/views/teachers/_search.html.erb
@@ -1,0 +1,8 @@
+<% if @teachers.any? %>
+  <% @teachers.each do |teacher| %>
+    <div class="teacherOption">
+      <h5 id="option-username"><%= teacher.username %></h5>
+      <%= teacher.firstname.capitalize + " " + teacher.lastname.capitalize %>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/teachers/new_invitation.html.erb
+++ b/app/views/teachers/new_invitation.html.erb
@@ -1,0 +1,12 @@
+<h1>Create Invitation</h1>
+
+<%= form_with scope: :rc_teacher, url: create_invitation_path, local: true do |f| %>
+  <%= f.label :username %>
+  <%= f.text_field :username, id: 'search-field' %>
+
+  <div id="search-options"></div>
+
+  <%= f.submit %>
+<% end %>
+
+<%= javascript_pack_tag 'search_ajax' %>

--- a/app/views/teachers/search.js.erb
+++ b/app/views/teachers/search.js.erb
@@ -1,0 +1,13 @@
+document.getElementById('search-options').innerHTML = "<%= j render 'search', object: @teachers %>"
+
+
+var teacherOptions = document.getElementsByClassName('teacherOption')
+
+if (teacherOptions) {
+  Array.from(teacherOptions).forEach(function(option) {
+    option.addEventListener('click', function(e) {
+      const textField = document.getElementById('search-field')
+      textField.value = document.getElementById('option-username').innerHTML
+    })
+  })
+}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,6 +32,9 @@ Rails.application.routes.draw do
   
   #TEACHER PAGES
   get '/home' => 'teachers#home', as: 'teacher_home'
+  get 'teachers/invitations/new' => 'teachers#new_invitation', as: 'new_invitation'
+  get '/teachers/search' => 'teachers#search'
+  post 'teachers/invitations' => 'teachers#create_invitation', as: 'create_invitation'
 
   # STUDENT PAGES
 

--- a/spec/models/review_center_spec.rb
+++ b/spec/models/review_center_spec.rb
@@ -15,4 +15,9 @@ RSpec.describe ReviewCenter, type: :model do
     it { is_expected.to validate_uniqueness_of(:email).case_insensitive }
     it { is_expected.to validate_uniqueness_of(:name).case_insensitive }
   end
+
+  context 'when validating associations' do
+    it { is_expected.to have_many(:rc_teachers) }
+    it { is_expected.to have_many(:rc_courses) }
+  end
 end

--- a/spec/requests/teachers_spec.rb
+++ b/spec/requests/teachers_spec.rb
@@ -1,16 +1,39 @@
 # require 'rails_helper'
 
-# RSpec.describe 'Teachers', type: :request do
-#   let!(:teacher) { create(:teacher) }
+RSpec.describe 'Teachers', type: :request do
+  let!(:teacher) { create(:teacher) }
+  let!(:review_center) { create(:review_center) }
 
-#   before do
-#     sign_in teacher, scope: :user
-#   end
+  describe 'GET /home' do
+    it 'has a success status' do
+      sign_in teacher, scope: :user
+      get teacher_home_path
+      expect(response).to have_http_status(:ok)
+    end
+  end
 
-#   describe 'GET /home' do
-#     it 'has a success status' do
-#       get teacher_home_path
-#       expect(response).to have_http_status(:ok)
-#     end
-#   end
-# end
+  describe 'invites a teacher' do
+    it 'has a success status' do
+      sign_in review_center, scope: :review_center
+      get new_invitation_path
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'creates rc_teacher with pending status' do
+      sign_in review_center, scope: :review_center
+      expect { post create_invitation_path, params: { rc_teacher: { username: teacher.username, review_center_id: review_center.id, status: 'pending' } } }.to change(RcTeacher, :count).by(1)
+    end
+
+    it 'redirects to authenticated_rc_root after creation' do
+      sign_in review_center, scope: :review_center
+      post create_invitation_path, params: { rc_teacher: { username: teacher.username, review_center_id: review_center.id, status: 'pending' } }
+      expect(response).to redirect_to(authenticated_rc_root_path)
+    end
+
+    it 'redirects to new_invitation path if creation fails' do
+      sign_in review_center, scope: :review_center
+      post create_invitation_path, params: { rc_teacher: { username: '', review_center_id: nil } }
+      expect(response).to redirect_to(new_invitation_path)
+    end
+  end
+end


### PR DESCRIPTION
### Story
As one of the requirements for this project is creating teachers for a review centers, I have added methods inside teachers controller whereas a review center can send invitations to teachers. By sending invitation, a new RcTeacher object will be created with a status "pending". The status will be updated once the teacher has accepted the invitation (this method is nor part of the scope of this PR.)

The current user (review center) will be able to type a username of the teacher, and a search query will run which will return the matching results while he is typing the username. 

Exclusion: UI

### Screenshot
![image](https://user-images.githubusercontent.com/81558435/137957165-807756c0-2ea7-44c8-acc8-388fae58c1f7.png)

### Resource for ajax request
https://www.rubyguides.com/2019/03/rails-ajax/