### PR TITLE
Displays error message when file upload fails

### DIFF
--- a/app/javascript/packs/direct_uploads.js
+++ b/app/javascript/packs/direct_uploads.js
@@ -1,4 +1,47 @@
+const errorMessage = (error) => {
+  let errorContent;
+
+  if (error.includes('Status')) {
+    const status = error.slice(error.indexOf('Status')).split(" ");
+    const statusCode = parseInt(status[status.length - 1])
+
+    if (statusCode === 413) {
+      errorContent = 'File is exceeding maximum of 100MB';
+    } else if (statusCode === 0) {
+      errorContent = 'Something went wrong from our end. Please try again later';
+    }
+    else {
+      errorContent = 'Something went wrong. Please try again';
+    }
+  } else {
+    errorContent = 'Something went wrong. Please try again';
+  }
+
+  return errorContent;
+}
+
+const removePreviousPendingProgress = () => {
+  const directUploadProgress = document.querySelectorAll('.direct-upload--pending')
+  if (directUploadProgress){
+    Array.from(directUploadProgress).forEach(function(element, index) {
+      if (index != 0) {
+        element.remove()
+      }
+    })
+  }
+
+  const directUploadComplete = document.querySelectorAll('.direct-upload--complete')
+  if (directUploadComplete){
+    Array.from(directUploadComplete).forEach(function(element, index) {
+      if (index != 0) {
+        element.remove()
+      }
+    })
+  }
+}
+
 addEventListener("direct-upload:initialize", event => {
+  removePreviousPendingProgress();
   const { target, detail } = event
   const { id, file } = detail
   target.insertAdjacentHTML("beforebegin", `
@@ -17,10 +60,13 @@ addEventListener("direct-upload:start", event => {
 })
 
 addEventListener("direct-upload:progress", event => {
+  removePreviousPendingProgress();
   const { id, progress } = event.detail
   const progressElement = document.getElementById(`direct-upload-progress-${id}`)
   progressElement.style.width = `${progress}%`
+  document.getElementById('save_lesson').disabled = true;
 })
+
 
 addEventListener("direct-upload:error", event => {
   event.preventDefault()
@@ -28,15 +74,13 @@ addEventListener("direct-upload:error", event => {
   const element = document.getElementById(`direct-upload-${id}`)
   element.classList.add("direct-upload--error")
   element.setAttribute("title", error)
+
+  element.innerHTML = errorMessage(error)
+  document.getElementById('save_lesson').disabled = false
 })
 
 addEventListener("direct-upload:end", event => {
   const { id } = event.detail
   const element = document.getElementById(`direct-upload-${id}`)
   element.classList.add("direct-upload--complete")
-})
-
-
-addEventListener('cloudinaryfail', event => {
-  console.log('Something Went Wrong')
 })

--- a/app/javascript/packs/upload_attachments.js
+++ b/app/javascript/packs/upload_attachments.js
@@ -1,9 +1,21 @@
 const upload_image = document.querySelector('.upload-image')
 const preview_image = document.querySelector('.preview-image')
 
+const removeProgressElement = () => {
+  const directUploadProgress = document.querySelectorAll('.direct-upload')
+  if (directUploadProgress){
+    Array.from(directUploadProgress).forEach(function(element) {
+      element.remove()
+      console.log("ERROR")
+    })
+  }
+}
+
 upload_image.addEventListener('change', function(e) {
   const file = e.target.files[0];
   preview_image.src = URL.createObjectURL(file)
+
+  removeProgressElement();
 })
 
 
@@ -13,4 +25,6 @@ const preview_video = document.querySelector('.preview-video')
 upload_video.addEventListener('change', function(e) {
   const file = e.target.files[0];
   preview_video.src = URL.createObjectURL(file)
+
+  removeProgressElement();
 })

--- a/app/views/lessons/new.html.erb
+++ b/app/views/lessons/new.html.erb
@@ -5,8 +5,9 @@
   </div>
 
     <div class="">
-      <%= f.label :teacher_subject_id %>
-      <%= f.select(:teacher_subject_id, @teacher_subjects.collect { |teacher_subject| [ teacher_subject.subject.name, teacher_subject.id ] }, {include_blank: "Select Subject "}, { :class => 'form-select mb-3 shadow-none' })%>
+      <% @options = @teacher_subjects.collect { |teacher_subject| [ teacher_subject.subject.name, teacher_subject.id ] } %>
+      <%= f.label :teacher_subject_id, 'Subject' %>
+      <%= f.select(:teacher_subject_id, @options, {}, { :class => 'form-select mb-3 shadow-none' })%>
     </div>
 
     <div class="">


### PR DESCRIPTION
### Story
As it was tried to upload a file exceeding 100mb, client receives no indication of error. To fix the issue, I have modified the event listener for direct-upload:error to include displaying of error message when the file upload fails for whatever determined reason. Also, previously, when the the same error happen as mentioned above, form cannot be resubmitted as the save button is disabled. I have updated save button attribute 'disabled' to true to allow resubmission of form after file upload error.

### Screenshot
![image](https://user-images.githubusercontent.com/81558435/138236407-02917801-b956-4f2e-9c7c-0f414f120330.png)
