### PR TITLE
Adds task for creating courses and subjects

### DIFF
--- a/app/assets/stylesheets/rc_courses.scss
+++ b/app/assets/stylesheets/rc_courses.scss
@@ -1,3 +1,4 @@
-// Place all the styles related to the rc_courses controller here.
-// They will automatically be included in application.css.
-// You can use Sass (SCSS) here: https://sass-lang.com/
+.course__assign {
+  max-height: 40rem;
+  overflow: scroll;
+}

--- a/app/assets/stylesheets/teacher_subjects.scss
+++ b/app/assets/stylesheets/teacher_subjects.scss
@@ -1,3 +1,4 @@
-// Place all the styles related to the teacher_subjects controller here.
-// They will automatically be included in application.css.
-// You can use Sass (SCSS) here: https://sass-lang.com/
+.subject__assign {
+  max-height: 40rem;
+  overflow: scroll;
+}

--- a/app/views/rc_courses/new.html.erb
+++ b/app/views/rc_courses/new.html.erb
@@ -1,20 +1,22 @@
 <div class="container">
-  <h1>Add courses to <%= current_review_center.name.capitalize %></h1>
+  <h1>Add courses to "<%= current_review_center.name.capitalize %>"</h1>
   
   <%= form_with scope: :rc_course, url: create_rc_course_path, local: true do |f| %>
     <% if @courses.any? %>
-      <% @courses.each do |course| %>
-        <div>
-          <% rc_course = current_review_center.rc_courses.find_by(course_id: course.id) %>
-          <%= f.check_box :course_id, { multiple: true, disabled: rc_course.present? }, course.id, false %>
-          <%= f.label :course_id, course.name%>
-          <% if rc_course.present? %>
-            <span class='text-muted'>(Added)</span>
-          <% end %>
-        </div>
-      <% end %>
+      <ul class="list-group list-group-flush course__assign">
+        <% @courses.each do |course| %>
+          <li class="list-group-item bg-transparent">
+            <% rc_course = current_review_center.rc_courses.find_by(course_id: course.id) %>
+            <%= f.check_box :course_id, { multiple: true, disabled: rc_course.present? }, course.id, false %>
+            <%= f.label :course_id, course.name%>
+            <% if rc_course.present? %>
+              <span class='text-muted'>(Added)</span>
+            <% end %>
+          </li>
+        <% end %>
+      </ul>
     <% end %>
   
-    <%= f.submit "Add Selected Courses" %>
+    <%= f.submit "Add Selected Courses", class: "btn btn-warning mb-2 mt-2" %>
   <% end %>
 </div>

--- a/app/views/teacher_subjects/new.html.erb
+++ b/app/views/teacher_subjects/new.html.erb
@@ -1,23 +1,30 @@
-<h1>Assign Subject to teacher</h1>
+<div class="container">
+  <h1>Assign subjects to "<%= @rc_teacher.teacher.firstname %>"</h1>
+  
+  <%= form_with scope: :teacher_subject, url: create_teacher_subject_path(@rc_teacher), local: true do |f| %>
+    <% if @rc_courses.any? %>
+      <% @rc_courses.each do |rc_course| %>
+        <a class="btn btn-outline-secondary d-block btn mb-2 mt-2" data-bs-toggle="collapse" href="#rc_course<%= rc_course.id %>" role="button" aria-expanded="false" aria-controls="rc_course<%= rc_course.id %>">
+          <h5 class="pt-1 text-dark"><%= rc_course.course.name %></h5>
+        </a>
 
-<%= form_with scope: :teacher_subject, url: create_teacher_subject_path(@rc_teacher), local: true do |f| %>
-  <% if @rc_courses.any? %>
-    <% @rc_courses.each do |rc_course| %>
-      <div>
-        <h5><%= rc_course.course.name %></h5>
-        <% rc_course.course.subjects.each do |subject| %>
-          <div>
-            <% teacher_subject = @rc_teacher.teacher_subjects.find_by(subject_id: subject.id) %>
-            <%= f.check_box :subject_id, { multiple: true, disabled: teacher_subject.present? }, subject.id, false %>
-            <%= f.label :subject_id, subject.name%>
-            <% if teacher_subject.present? %>
-              <span class='text-muted'>(Assigned)</span>
+        <div class="collapse subject__assign" id="rc_course<%= rc_course.id %>">
+          <ul class="list-group list-group-flush">
+            <% rc_course.course.subjects.order(:name).each do |subject| %>
+              <li class="list-group-item bg-transparent">
+                <% teacher_subject = @rc_teacher.teacher_subjects.find_by(subject_id: subject.id) %>
+                <%= f.check_box :subject_id, { multiple: true, disabled: teacher_subject.present? }, subject.id, false %>
+                <%= f.label :subject_id, subject.name%>
+                <% if teacher_subject.present? %>
+                  <span class='text-muted'>(Assigned)</span>
+                <% end %>
+              </li>
             <% end %>
-          </div>
-        <% end %>
-      </div>
+          </ul>
+        </div>
+      <% end %>
     <% end %>
+  
+    <%= f.submit "Assign Selected Subjects", class: "btn btn-warning mb-2 mt-2" %>
   <% end %>
-
-  <%= f.submit "Assign Selected Subjects" %>
-<% end %>
+</div>

--- a/lib/tasks/courses.rake
+++ b/lib/tasks/courses.rake
@@ -1,0 +1,22 @@
+namespace :courses do
+  desc 'TODO'
+  task seed_courses: :environment do
+    course_subjects = {
+      'Civil Engineering':
+        ['Algebra', 'Plane Trigonometry', 'Spherical Trigonometry', 'Analytic Geometry', 'Descriptive Geometry', 'Solid Geometry', 'Differential Calculus', 'Integral Calculus', 'Highway and Railroad Surveying', 'Advance Surveying', 'Fluid properties', 'Hydrostatic Pressures', 'Fluid Flow', 'Bouyancy and Flotation', 'Relative Equilibrium of Liquids', 'Hydrodynamics', 'Water Supply', 'Soil Properties', 'Soil Classification', 'Fluid Through Soil Mass', 'Stresses in soil mass', 'Soil strength and Test', 'Bearing Capacity', 'Compaction', 'Consolidation and Settlement', 'Lateral Earth pressures', 'Slope Stability', 'Engineering Mechanics', 'Strength of materials', 'Theory of Structures', 'Analysis and Design of Concrete Structures', 'Analysis and Design of Steel Structures', 'Analysis and Design of Timber Structures', 'Analysis and Design of Foundation'],
+      Psychology:
+        ['Advanced Theories of Personality', 'Advanced Abnormal Psychology', 'Advanced Psychological Assessment', 'Psychological Counseling and Psychotherapy'],
+      Nursing:
+        ['Community Health Nursing', 'Care of Healthy/At Risk Mother and Child', 'Care of Clients with Physiologic and Psychosocial Alterations (Part A)', 'Care of Clients with Physiologic and Psychosocial Alterations (Part B)', 'Care of Clients with Physiologic and Psychosocial Alterations (Part C)']
+    }
+
+    course_subjects.each do |course_name, subjects|
+      course = Course.where(name: course_name).first_or_create!
+      subjects.each do |subject|
+        course.subjects.where(name: subject).first_or_create!
+      end
+    end
+
+    puts "#{course_subjects.count} courses has been updated."
+  end
+end


### PR DESCRIPTION
### Story
As the functionality for adding courses and subjects that could be selected by the review center when adding a course to offer and assigning subjects to teachers, respectively, I have added a task that could be updated and run whenever new data have to be added.

I have modified the respective pages to enhance the presentation of these data(courses and subjects) to the client.

### Screenshots

**Assigning subjects**
![image](https://user-images.githubusercontent.com/81558435/139871193-94217054-1896-49d5-904c-16c6c0ccd1c3.png)
![image](https://user-images.githubusercontent.com/81558435/139870801-6c611027-05e9-4c65-8a23-dd212fb6ac3a.png)

**Assigning course**
![image](https://user-images.githubusercontent.com/81558435/139870861-bfa79fd2-8cda-4d31-b1de-6e3887a5bd77.png)

